### PR TITLE
Fix puccinialin on GraalPy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-13
           # Windows x86_64
           - windows-latest
-        python_version: ["3.9", "3.13"]
+        python_version: ["3.9", "3.13", "graalpy@3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Hello,

this adds support for GraalPy. GraalPy has slightly different format of `SOABI`, for example:

* `graalpy242-311-native-aarch64-darwin`
* `graalpy242-311-native-x86_64-linux`
* `graalpy242-311-native-x86_64-win32`

(`native` is toolchain identifier, there's no `-gnu` suffix for linux, darwin and windows include architecture)

I've tested this in my fork: https://github.com/steve-s/puccinialin/actions/runs/15020011836