### PR TITLE
Change cargo version check to use shell=True

### DIFF
--- a/src/puccinialin/_setup_rust.py
+++ b/src/puccinialin/_setup_rust.py
@@ -131,5 +131,5 @@ def setup_rust(
     }
 
     print("Checking if cargo is installed", file=file)
-    check_call(["cargo", "--version"], env={**os.environ, **extra_env})
+    check_call("cargo --version", env={**os.environ, **extra_env}, shell=True)
     return extra_env


### PR DESCRIPTION
I'll admit I'm not very handy with Windows shells in general, but I would like to make a package I help maintain installable for all users, Windows included. I have confirmed that `cargo.exe` is in fact present as expected, it's just that this subshell doesn't seem to find it.

Using `shell=True` appears to work on Windows.