### PR TITLE
Fix parallel runs with a file lock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Fix parallel runs with a file lock (see https://github.com/rust-lang/rustup/issues/4607)
+
 ## v0.1.5
 
 - Add license declaration and files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "puccinialin"
-version = "0.1.5"
+version = "0.1.6"
 description = "Install rust into a temporary directory for boostrapping a rust-based build backend"
 readme = "README.md"
 authors = [
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "filelock>=3.19.1,<4.0.0",
     "httpx>=0.28.1,<0.29",
     "platformdirs>=4.3.6,<5",
     "tqdm>=4.67.1,<5",

--- a/tests/parallelism.dockerfile
+++ b/tests/parallelism.dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/astral-sh/uv:python3.14-trixie
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1
+
+COPY pyproject.toml uv.lock ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project
+
+COPY src src
+COPY README.md ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen
+
+ENV PATH="/app/.venv/bin:$PATH"

--- a/tests/parallelism.sh
+++ b/tests/parallelism.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Test that running in parallel doesn't fail
+# https://github.com/rust-lang/rustup/issues/4607
+
+docker build -f parallelism.dockerfile -t puccinialin-parallelism ..
+
+docker run --rm -i puccinialin-parallelism /bin/bash -c "
+  uv run python -c 'from puccinialin import setup_rust; setup_rust(\"foo\")' & \
+  uv run python -c 'from puccinialin import setup_rust; setup_rust(\"foo\")' & \
+  uv run python -c 'from puccinialin import setup_rust; setup_rust(\"foo\")' & \
+  wait -n
+"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
 
 [[package]]
 name = "anyio"
@@ -45,6 +49,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.20.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922, upload-time = "2025-10-08T18:03:50.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054, upload-time = "2025-10-08T18:03:48.35Z" },
 ]
 
 [[package]]
@@ -107,6 +135,8 @@ name = "puccinialin"
 version = "0.1.5"
 source = { editable = "." }
 dependencies = [
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "filelock", version = "3.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "httpx" },
     { name = "platformdirs" },
     { name = "tqdm" },
@@ -119,6 +149,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "filelock", specifier = ">=3.19.1,<4.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "platformdirs", specifier = ">=4.3.6,<5" },
     { name = "tqdm", specifier = ">=4.67.1,<5" },


### PR DESCRIPTION
We lock a file next to the `rustup-init` download to ensure only one rustup is active at a time. See https://github.com/rust-lang/rustup/issues/4607 for why this is necessary.