### PR TITLE
Install Rust with an explicit target triple

### DIFF
--- a/src/puccinialin/_setup_rust.py
+++ b/src/puccinialin/_setup_rust.py
@@ -62,7 +62,11 @@ def download_rustup(
 
 
 def install_rust(
-    rustup_init: Path, rustup_home: Path, cargo_home: Path, file: typing.IO
+    rustup_init: Path,
+    rustup_home: Path,
+    cargo_home: Path,
+    file: typing.IO,
+    target_triple: str,
 ):
     """Run rustup to install rust and cargo"""
     print(f"Installing rust to {rustup_home}", file=file)
@@ -73,6 +77,8 @@ def install_rust(
             "--no-modify-path",
             "--profile",
             "minimal",
+            "--default-host",
+            target_triple,
         ],
         env={
             **os.environ,
@@ -128,7 +134,7 @@ def setup_rust(
     # https://github.com/rust-lang/rustup/issues/4607
     lock = FileLock(rustup_init.with_suffix(".lock"))
     with lock:
-        install_rust(rustup_init, rustup_home, cargo_home, file)
+        install_rust(rustup_init, rustup_home, cargo_home, file, target_triple)
 
     # Step 4: Construct and return a dict of changed environment variables to use this rust installation
     new_path = f"{cargo_home.joinpath('bin')}{target.env_path_separator()}{os.environ.get('PATH')}"


### PR DESCRIPTION
Currently, `puccinialin` depends on the cache to install `rustup` instead of the target triple. This coincidentally works out 99% of the time because the cache and the desired version of Rust would be the same. However, if you had an undesired pre-existing installation of `rustup`, this can cause a drift in the intended toolchain installation, as `rustup` will attempt to use the previously cached settings.

See https://rust-lang.github.io/rustup/installation/windows.html

> By default rustup on Windows configures Rust to target the MSVC ABI, that is a target tuple of either i686-pc-windows-msvc, x86_64-pc-windows-msvc, or aarch64-pc-windows-msvc depending on the CPU architecture of the host Windows OS. The toolchains that rustup chooses to install, unless told otherwise through the [toolchain specification](https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification), will be compiled to run on that target tuple host and will target that triple by default.

Closes #35