### PR TITLE
Release v0.1.12

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.12
+
+- Fix race condition in rustup-init downloads during concurrent setup
+  ([#38](https://github.com/konstin/puccinialin/pull/38))
+
 ## 0.1.11
 
 - Install Rust with an explicit target triple ([#36](https://github.com/konstin/puccinialin/pull/36))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "puccinialin"
-version = "0.1.11"
+version = "0.1.12"
 description = "Install rust into a temporary directory for boostrapping a rust-based build backend"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "puccinialin"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
- Fix race condition in rustup-init downloads during concurrent setup ([#38](https://github.com/konstin/puccinialin/pull/38))