### PR TITLE
Fix platform detection for 32-bit Linux

### DIFF
--- a/src/puccinialin/_target.py
+++ b/src/puccinialin/_target.py
@@ -79,6 +79,8 @@ def get_triple(file: typing.IO) -> str:
         elif not linux == "linux":
             print(f"Unrecognized linux platform {sysconfig_platform}", file=file)
             sys.exit(1)
+        if arch == "i386":
+            arch = "i686"
         target = f"{arch}-unknown-{linux}-{libc}"
     # macOS (both Intel and arm)
     elif "darwin" in sysconfig_platform:


### PR DESCRIPTION
Hi! xref https://github.com/HypothesisWorks/hypothesis/issues/4789 and https://github.com/scipy/scipy/pull/25596. The rustup target is `i686-unknown-linux-gnu`.

I observed this in a Linux i686 container that doesn't have cargo installed and thus relies on puccinialin. Example CI job: https://github.com/scipy/scipy/actions/runs/28950762210/job/85896617891#step:3:194. Maybe there are more cases for other less proliferated architecture triplets based on differences in Python SOABI detection and Rust, but it's the only one I noticed (or bothered to look at) so far. :)