### PR TITLE
Release v0.1.13

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.13
+
+- Fix platform detection for 32-bit Linux by mapping Python's `i386` architecture to Rust's `i686` target
+  ([#40](https://github.com/konstin/puccinialin/pull/40))
+
 ## 0.1.12
 
 - Fix race condition in rustup-init downloads during concurrent setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "puccinialin"
-version = "0.1.12"
+version = "0.1.13"
 description = "Install rust into a temporary directory for boostrapping a rust-based build backend"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "puccinialin"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
- Fix platform detection for 32-bit Linux by mapping Python's `i386` architecture to Rust's `i686` target
  ([#40](https://github.com/konstin/puccinialin/pull/40))