### PR TITLE
Fix PyPy target detection

### DIFF
--- a/src/puccinialin/_target.py
+++ b/src/puccinialin/_target.py
@@ -54,7 +54,11 @@ def get_triple(file: typing.IO) -> str:
     soabi = sysconfig.get_config_var("SOABI")
     if soabi:
         print(f"Python reports SOABI: {soabi}", file=file)
-        if soabi.count("-") == 1:
+        if soabi.startswith("pypy"):
+            sysconfig_platform = (
+                sysconfig.get_config_var("MULTIARCH") or sysconfig.get_platform()
+            )
+        elif soabi.count("-") == 1:
             _python, sysconfig_platform = soabi.split("-", maxsplit=2)
         else:
             _python_interpreter, _python_version, sysconfig_platform = soabi.split(

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,21 @@
+from io import StringIO
+from unittest import TestCase
+from unittest.mock import patch
+
+from puccinialin._target import get_triple
+
+
+class GetTripleTest(TestCase):
+    def test_pypy_uses_multiarch_for_target(self):
+        config_vars = {
+            "SOABI": "pypy311-pp73",
+            "MULTIARCH": "x86_64-linux-gnu",
+        }
+
+        with patch(
+            "puccinialin._target.sysconfig.get_config_var",
+            side_effect=config_vars.get,
+        ):
+            target = get_triple(StringIO())
+
+        self.assertEqual(target, "x86_64-unknown-linux-gnu")


### PR DESCRIPTION
Fixes #42.

PyPy's SOABI lacks a platform component, so `pypy311-pp73` was parsed as platform `pp73` and target detection stopped. Use PyPy's `MULTIARCH` value (with the existing platform fallback) before the existing target conversion, covered by a regression test.

Tested with `python -m unittest discover -s tests -p 'test*.py'`, Ruff, ty, and an actual PyPy 3.11 target probe.
