### PR TITLE
Respect `RUSTUP_UPDATE_ROOT`

### DIFF
--- a/src/puccinialin/_setup_rust.py
+++ b/src/puccinialin/_setup_rust.py
@@ -8,7 +8,6 @@ import sys
 import typing
 from pathlib import Path
 from subprocess import check_call
-from urllib.parse import urljoin
 
 from filelock import FileLock
 
@@ -124,9 +123,12 @@ def setup_rust(
     rustup_init = rustup_init_dir.joinpath("rustup-init").with_suffix(
         target.exe_suffix()
     )
-    url = urljoin(
-        os.environ.get("RUSTUP_UPDATE_ROOT", "https://static.rust-lang.org"),
-        f"rustup/dist/{target_triple}/rustup-init{target.exe_suffix()}",
+    rustup_update_root = (
+        os.environ.get("RUSTUP_UPDATE_ROOT") or "https://static.rust-lang.org/rustup"
+    )
+    url = (
+        f"{rustup_update_root.rstrip('/')}/dist/{target_triple}/"
+        f"rustup-init{target.exe_suffix()}"
     )
 
     # Lock the download as well as the install: concurrent callers otherwise

--- a/src/puccinialin/_setup_rust.py
+++ b/src/puccinialin/_setup_rust.py
@@ -8,6 +8,7 @@ import sys
 import typing
 from pathlib import Path
 from subprocess import check_call
+from urllib.parse import urljoin
 
 from filelock import FileLock
 
@@ -123,7 +124,10 @@ def setup_rust(
     rustup_init = rustup_init_dir.joinpath("rustup-init").with_suffix(
         target.exe_suffix()
     )
-    url = f"https://static.rust-lang.org/rustup/dist/{target_triple}/rustup-init{target.exe_suffix()}"
+    url = urljoin(
+        os.environ.get("RUSTUP_UPDATE_ROOT", "https://static.rust-lang.org"),
+        f"rustup/dist/{target_triple}/rustup-init{target.exe_suffix()}",
+    )
 
     # Lock the download as well as the install: concurrent callers otherwise
     # each download to their own tmp file and both os.replace the same target,


### PR DESCRIPTION
Hi! 

I've introduced an environment variable, as specified in the [rust documentation](https://rust-lang.github.io/rustup/environment-variables.html), to use a custom rustup update root.

Is this something you would be interested in?