### PR TITLE
Release v0.1.14

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.14
+
+- Respect `RUSTUP_UPDATE_ROOT` when downloading rustup-init ([#44](https://github.com/konstin/puccinialin/pull/44))
+- Support PyPy platform detection ([#45](https://github.com/konstin/puccinialin/pull/45))
+
 ## 0.1.13
 
 - Fix platform detection for 32-bit Linux by mapping Python's `i386` architecture to Rust's `i686` target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "puccinialin"
-version = "0.1.13"
+version = "0.1.14"
 description = "Install rust into a temporary directory for boostrapping a rust-based build backend"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "puccinialin"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
- Respect `RUSTUP_UPDATE_ROOT` when downloading rustup-init ([#44](https://github.com/konstin/puccinialin/pull/44))
- Support PyPy platform detection ([#45](https://github.com/konstin/puccinialin/pull/45))
